### PR TITLE
[FIX] Apply singleton pattern to Firebase Client

### DIFF
--- a/FoodBookApp/DAO/Firebase/ExampleDAOFirebase.swift
+++ b/FoodBookApp/DAO/Firebase/ExampleDAOFirebase.swift
@@ -10,7 +10,7 @@ import Foundation
 class ExampleDAOFirebase: ExampleDAO {
     static var shared: ExampleDAO = ExampleDAOFirebase()
     
-    private var client: FirebaseClient = FirebaseClient()
+    private var client: FirebaseClient = FirebaseClient.shared
     
     func getSpots() async throws {
         do {

--- a/FoodBookApp/Persitence/Firebase.swift
+++ b/FoodBookApp/Persitence/Firebase.swift
@@ -13,9 +13,10 @@ import FirebaseFirestore
 
 class FirebaseClient {
     var db: Firestore
-    // TODO: add variable for auth service
     
-    init() {
+    static var shared = FirebaseClient()
+    
+    private init() {
         self.db = Firestore.firestore()
     }
     


### PR DESCRIPTION
Refactors Firebase.swift to use Singleton pattern. Now accessed at different DAOs through the `shared` attribute

Closes #29 