### PR TITLE
[UI] Change app name

### DIFF
--- a/FoodBookApp.xcodeproj/project.pbxproj
+++ b/FoodBookApp.xcodeproj/project.pbxproj
@@ -764,6 +764,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoodBookApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = FoodBook;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Please allow camera access";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "";
 				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "";
@@ -796,6 +797,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoodBookApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = FoodBook;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Please allow camera access";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "";
 				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "";


### PR DESCRIPTION
- Changed the name of the app when downloading it (the "App" at the end is gone)
- Closes #32 

<img alt="app-name" height="500" src="https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/8f817a6c-1212-49ef-8346-621eee6c389d">