### PR TITLE
[FIX] Backend URL as Environment Variable

### DIFF
--- a/FoodBookApp.xcodeproj/xcshareddata/xcschemes/FoodBookApp.xcscheme
+++ b/FoodBookApp.xcodeproj/xcshareddata/xcschemes/FoodBookApp.xcscheme
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6CC928FE2B84FB0700EDDE78"
+               BuildableName = "FoodBookApp.app"
+               BlueprintName = "FoodBookApp"
+               ReferencedContainer = "container:FoodBookApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6CC9290E2B84FB0900EDDE78"
+               BuildableName = "FoodBookAppTests.xctest"
+               BlueprintName = "FoodBookAppTests"
+               ReferencedContainer = "container:FoodBookApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6CC929182B84FB0900EDDE78"
+               BuildableName = "FoodBookAppUITests.xctest"
+               BlueprintName = "FoodBookAppUITests"
+               ReferencedContainer = "container:FoodBookApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6CC928FE2B84FB0700EDDE78"
+            BuildableName = "FoodBookApp.app"
+            BlueprintName = "FoodBookApp"
+            ReferencedContainer = "container:FoodBookApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "BACKEND_URL"
+            value = "https://backend-aii7.onrender.com"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6CC928FE2B84FB0700EDDE78"
+            BuildableName = "FoodBookApp.app"
+            BlueprintName = "FoodBookApp"
+            ReferencedContainer = "container:FoodBookApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FoodBookApp/Services/BackendService.swift
+++ b/FoodBookApp/Services/BackendService.swift
@@ -13,9 +13,14 @@ final class BackendService: NSObject, ObservableObject {
         let category: String
         let user: String
     }
+    
+    private let backendUrl = ProcessInfo.processInfo.environment["BACKEND_URL"]
 
-    func performAPICall(uid: String) async throws -> [String]{
-        let url = URL(string: "https://foodbook-app-backend.2.us-1.fl0.io/recommendation/\(uid)")!
+    func performAPICall(uid: String) async throws -> [String ]{
+        guard let validUrl = backendUrl else {
+            throw NSError() // TODO: Should throw specialized error
+        }
+        let url = URL(string: "\(validUrl)/recommendation/\(uid)")!
         let (data, _) = try await URLSession.shared.data(from: url)
         print(data)
         let wrapper = try JSONDecoder().decode(Answer.self, from: data)


### PR DESCRIPTION
Moves the backend url to the environment variables. 

This should be setup within the included schema file at `FoodBookApp.xcodeproj/xcshareddata/xcschemes/FoodBookApp.xcscheme`

To check go to Product > Scheme > Edit Scheme. 
On the Run tab select Arguments and in the Environment Variables section you should see the follwing:

![Screenshot 2024-04-09 at 9 08 12 AM](https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/61592394/2e1c0a0f-c9c6-45df-b1e1-812a9fc1693d)

Please review that the ForYou page works on your devices/emulators!

Closes #68 

TBD: Left a TODO for better error handling once we define the type of errors.
