### PR TITLE
[FIX] Display names instead of emails on reviews

### DIFF
--- a/FoodBookApp/Models/Review.swift
+++ b/FoodBookApp/Models/Review.swift
@@ -15,6 +15,10 @@ struct ReviewStats: Codable, Equatable, Hashable {
     let waitTime: Int
 }
 
+struct UserInfo: Codable, Equatable, Hashable {
+    let id: String
+    let name: String?
+}
 struct Review: Codable, Equatable, Hashable, Identifiable {
     @DocumentID var id: String?
     let content: String!
@@ -23,5 +27,5 @@ struct Review: Codable, Equatable, Hashable, Identifiable {
     let ratings: ReviewStats
     let selectedCategories: [String]
     let title: String!
-    let user: String // AuthoUserModel.uid from Authentication (getAuthenticatedUser)
+    let user: UserInfo
 }

--- a/FoodBookApp/Services/AuthService.swift
+++ b/FoodBookApp/Services/AuthService.swift
@@ -17,12 +17,14 @@ struct AuthDataResultModel {
     let email: String?
     let photoUrl: String?
     let isAnonymous: Bool
+    let name: String?
     
     init(user: User) {
         self.uid = user.uid
         self.email = user.email
         self.photoUrl = user.photoURL?.absoluteString
         self.isAnonymous = user.isAnonymous
+        self.name = user.displayName
     }
 }
 

--- a/FoodBookApp/UI/Views/Bookmarks/BookmarksView.swift
+++ b/FoodBookApp/UI/Views/Bookmarks/BookmarksView.swift
@@ -13,6 +13,14 @@ struct BookmarksView: View {
     //TODO: move this to sign out view if created
     let notify = NotificationHandler()
     
+    var user: AuthDataResultModel? {
+        do {
+            return try AuthService.shared.getAuthenticatedUser()
+        } catch {
+            return nil
+        }
+    }
+    
     var body: some View {
         
         VStack {
@@ -40,7 +48,8 @@ struct BookmarksView: View {
             })
             .buttonStyle(.borderedProminent)
             .padding()
-            
+            Text(user?.name ?? "")
+            Text(user?.email ?? "")
         }
 
     }

--- a/FoodBookApp/UI/Views/CreateReview/CreateReview2View.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview2View.swift
@@ -128,7 +128,7 @@ struct CreateReview2View: View {
                                                                 waitTime: waitingTime),
                                                                selectedCategories: lowercasedCategories,
                                                                title: trimmedTitle == "" ? nil : trimmedTitle,
-                                                               user: UserInfo(id:"", name:"") ) //TODO: Should get a UserInfo object from the view model
+                                                               user: UserInfo(id: model.username, name: model.user) )
                                         do {
                                             let reviewId = try await model.addReview(review: newReview)
                                             try await model.addReviewToSpot(spotId: spotId, reviewId: reviewId)
@@ -235,7 +235,7 @@ struct CreateReview2View: View {
         } message: {
             Text("Please make sure to at least fill out all the star ratings")
         }.task {
-            _ = try? await model.getUsername()
+            _ = try? await model.getUserInfo()
         }
     }
     

--- a/FoodBookApp/UI/Views/CreateReview/CreateReview2View.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview2View.swift
@@ -128,7 +128,7 @@ struct CreateReview2View: View {
                                                                 waitTime: waitingTime),
                                                                selectedCategories: lowercasedCategories,
                                                                title: trimmedTitle == "" ? nil : trimmedTitle,
-                                                               user: model.username)
+                                                               user: UserInfo(id:"", name:"") ) //TODO: Should get a UserInfo object from the view model
                                         do {
                                             let reviewId = try await model.addReview(review: newReview)
                                             try await model.addReviewToSpot(spotId: spotId, reviewId: reviewId)

--- a/FoodBookApp/UI/Views/CreateReview/CreateReview2ViewModel.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview2ViewModel.swift
@@ -15,6 +15,7 @@ class CreateReview2ViewModel {
     private let spotRepository: SpotRepository = SpotRepositoryImpl.shared
     private let utils = Utils.shared
     var username: String = ""
+    var user: String?
     
     init() {}
     
@@ -48,8 +49,9 @@ class CreateReview2ViewModel {
         }
     }
     
-    func getUsername() async throws {
+    func getUserInfo() async throws {
         self.username = try await utils.getUsername()
+        self.user = try await utils.getUser()
     }
     
 }

--- a/FoodBookApp/UI/Views/SpotDetail/ReviewsView.swift
+++ b/FoodBookApp/UI/Views/SpotDetail/ReviewsView.swift
@@ -48,7 +48,7 @@ struct ReviewsView: View {
                                     }.padding()
                                     HStack {
                                         Spacer()
-                                        Text(review.user)
+                                        Text(review.user.name ?? "-")
                                             .foregroundColor(.gray)
                                     }.padding(.horizontal, 10)
                                     
@@ -151,7 +151,7 @@ struct ReviewsView: View {
                 ratings: ReviewStats(cleanliness: 5, foodQuality: 5, service: 5, waitTime: 4),
                 selectedCategories: ["Homemade", "Dessert"],
                 title: "Me fascina!!",
-                user: "Juan Pedro Gonzalez" // TODO: will be user uid, might need to add antoher field for email
+                user: UserInfo(id: "juan.pg", name: "Juan Pedro Gonzalez") // TODO: will be user uid, might need to add antoher field for email
             ),
             Review(
                 content: "La comida me gustó pero la atención fue pésima, se demoró muchísimo, lástima.",
@@ -164,7 +164,7 @@ struct ReviewsView: View {
                 
                     selectedCategories: ["Poultry", "Rice", "Soup"],
                     title: "No lo recomiendo.",
-                    user: "Mariana Martínez"
+                user: UserInfo(id: "mmz", name:"Mariana Martínez")
             )
             
         ])

--- a/FoodBookApp/Utils/Utils.swift
+++ b/FoodBookApp/Utils/Utils.swift
@@ -42,6 +42,7 @@ final class Utils {
         return now >= startTime && now <= endTime
     }
     
+    //User ID
     func getUsername() async throws -> String {
         do {
             let email = try AuthService.shared.getAuthenticatedUser().email
@@ -54,6 +55,20 @@ final class Utils {
                 }
             } else {
                 throw NSError(domain: "Google", code: 0, userInfo: [NSLocalizedDescriptionKey: "Email not found"])
+            }
+        } catch {
+            throw error
+        }
+    }
+    
+    //User name
+    func getUser() async throws -> String? {
+        do {
+            let name = try AuthService.shared.getAuthenticatedUser().name
+            if let name = name {
+                return String(name)
+            } else {
+                throw NSError(domain: "Google", code: 0, userInfo: [NSLocalizedDescriptionKey: "User not found"])
             }
         } catch {
             throw error


### PR DESCRIPTION
Commit d087d6e93d28abca7ca8bd4da789e600cf1b5c62
* AuthDataResult model now has property `name`
* Adds example usage to Bookmarks view (see below)

<img alt="simulator screenshot"  height="700" src="https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/61592394/d798aede-c46f-47b7-b80d-0cff9e55cae7">

Pending
* user model changes on reviews so both email and display name are stored
* considerations on the issue #58 discussion
* considerations if new sign-in methods are added

Closes #58 