### PR TITLE
[FIX] Update UI to show category aggregation and top only top categories in browse.

### DIFF
--- a/FoodBookApp/Models/Spot.swift
+++ b/FoodBookApp/Models/Spot.swift
@@ -30,9 +30,14 @@ struct ReviewDataDTO: Codable, Equatable, Hashable {
     let userReviews: [DocumentReference]
 }
 
+struct Category: Codable, Equatable, Hashable {
+    let name: String
+    let count: Int
+}
+
 struct SpotDTO: Codable, Equatable, Hashable {
     @DocumentID var id: String?
-    let categories: [String]
+    let categories: [Category]
     let location: GeoPoint
     let name: String
     let price: String
@@ -43,7 +48,7 @@ struct SpotDTO: Codable, Equatable, Hashable {
 
 struct Spot: Codable, Equatable, Hashable {
     @DocumentID var id: String?
-    let categories: [String]
+    let categories: [Category]
     let location: GeoPoint
     let name: String
     let price: String

--- a/FoodBookApp/UI/Components/HCategoryList.swift
+++ b/FoodBookApp/UI/Components/HCategoryList.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct HCategoryList: View {
-    let categories : [String]
+    let categories : [Category]
     let color : Color
     
     var body: some View {
@@ -16,7 +16,7 @@ struct HCategoryList: View {
             HStack {
                 ForEach(categories, id: \.self){
                     cat in
-                    Text(cat.capitalized)
+                    Text(cat.name.capitalized)
                         .padding(8)
                         .background(color.opacity(0.2))
                         .cornerRadius(8)
@@ -31,7 +31,8 @@ struct HCategoryList: View {
 
 #Preview {
     HCategoryList(
-        categories: ["Vegan", "Sandwich", "Bowl", "Healthy", "..."],
+        categories: [ Category(name: "sandwich", count: 1),  Category(name: "healthy", count: 1),  Category(name: "organic", count: 1),  Category(name: "fast", count: 2),  Category(name: "burger", count: 2),  Category(name: "low-fat", count: 1),  Category(name: "fries", count: 1)]
+,
         color: Color.gray
     )
 }

--- a/FoodBookApp/UI/Components/SpotCard.swift
+++ b/FoodBookApp/UI/Components/SpotCard.swift
@@ -14,7 +14,7 @@ struct SpotCard: View {
     let minTime : Int
     let maxTime : Int
     let distance : String
-    let categories : [String]
+    let categories : [Category]
     let imageLinks : [String]
     let price : String
     
@@ -60,7 +60,8 @@ struct SpotCard: View {
         minTime: 25,
         maxTime: 30,
         distance: "99+",
-        categories: ["Vegan", "Sandwich", "Bowl", "Healthy", "..."],
+        categories:[ Category(name: "sandwich", count: 1),  Category(name: "healthy", count: 1),  Category(name: "organic", count: 1),  Category(name: "fast", count: 2),  Category(name: "burger", count: 2),  Category(name: "low-fat", count: 1),  Category(name: "fries", count: 1)]
+,
         imageLinks: [
             "https://images.unsplash.com/photo-1546069901-ba9599a7e63c?q=80&w=2380&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
             "https://images.unsplash.com/photo-1493770348161-369560ae357d?q=80&w=2370&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",

--- a/FoodBookApp/UI/Views/Browse/BrowseView.swift
+++ b/FoodBookApp/UI/Views/Browse/BrowseView.swift
@@ -21,7 +21,7 @@ struct BrowseView: View {
                             minTime: spot.waitTime.min,
                             maxTime: spot.waitTime.max,
                             distance: spot.distance ?? "-",
-                            categories: spot.categories,
+                            categories: Array(Utils.shared.highestCategories(spot: spot).prefix(5)),
                             imageLinks: spot.imageLinks ?? [],
                             price: spot.price
                         )

--- a/FoodBookApp/UI/Views/SpotDetail/SpotDetailView.swift
+++ b/FoodBookApp/UI/Views/SpotDetail/SpotDetailView.swift
@@ -36,8 +36,8 @@ struct SpotDetailView: View {
                         // Categories
                         ScrollView(.horizontal) {
                             HStack {
-                                ForEach(model.spot.categories, id: \.self) { cat in
-                                    Text(cat.capitalized)
+                                ForEach(Utils.shared.highestCategories(spot: model.spot), id: \.self) { cat in
+                                    Text("\(cat.name.capitalized) (\(cat.count))")
                                         .font(.system(size: 14))
                                         .bold()
                                         .foregroundColor(.black)

--- a/FoodBookApp/Utils/Utils.swift
+++ b/FoodBookApp/Utils/Utils.swift
@@ -74,4 +74,11 @@ final class Utils {
             throw error
         }
     }
+    
+    func highestCategories(spot: Spot) -> [Category] {
+        return spot.categories.sorted { cat1, cat2 in
+            cat2.count < cat1.count
+        }
+        
+    }
 }


### PR DESCRIPTION
Updated the UI as follows based on the comments on the Viva Voce.

<img src=https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/61592394/22a1f13c-9278-47ad-9418-ac84ff889461 height=500>

<img src=https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/61592394/6a77ed44-7281-4550-87a2-5337596d86d4 height=500>


closes #59 