### PR TITLE
[FEATURE] Save a local copy of the image to file storage

### DIFF
--- a/FoodBookApp.xcodeproj/project.pbxproj
+++ b/FoodBookApp.xcodeproj/project.pbxproj
@@ -1041,7 +1041,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"FoodBookApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = AX26HDBNSN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoodBookApp/Info.plist;
@@ -1061,7 +1061,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp;
+				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp.laura;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -1077,7 +1077,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"FoodBookApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = AX26HDBNSN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoodBookApp/Info.plist;
@@ -1097,7 +1097,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp;
+				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp.laura;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/FoodBookApp.xcodeproj/project.pbxproj
+++ b/FoodBookApp.xcodeproj/project.pbxproj
@@ -1041,7 +1041,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"FoodBookApp/Preview Content\"";
-				DEVELOPMENT_TEAM = AX26HDBNSN;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoodBookApp/Info.plist;
@@ -1061,7 +1061,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp.laura;
+				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -1077,7 +1077,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"FoodBookApp/Preview Content\"";
-				DEVELOPMENT_TEAM = AX26HDBNSN;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoodBookApp/Info.plist;
@@ -1097,7 +1097,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp.laura;
+				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/FoodBookApp/Models/ReviewDraft.swift
+++ b/FoodBookApp/Models/ReviewDraft.swift
@@ -15,10 +15,10 @@ struct ReviewDraftStats: Codable, Equatable, Hashable {
 }
 
 struct ReviewDraft: Codable, Equatable, Hashable {
-    let content: String
-    //let imagePath: String!
-    let ratings: ReviewDraftStats
     let selectedCategories: [String]
+    let ratings: ReviewDraftStats
+    let image: String //this is a path
     let title: String
+    let content: String
     let upload: Bool
 }

--- a/FoodBookApp/SQLite/DBManager.swift
+++ b/FoodBookApp/SQLite/DBManager.swift
@@ -134,6 +134,37 @@ class DBManager {
         }
     }
     
+    func deleteImage(spot: String) {
+        do {
+            if let row = try db.pluck(drafts.filter(self.spot == spot)) {
+                let image = try row.get(self.image)
+                if (image != "") {
+                    let imagePath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent(image)
+                    try FileManager.default.removeItem(atPath: imagePath.path)
+                }
+            }
+        } catch {
+            print("Error deleting image of spot: \(error.localizedDescription)")
+        }
+        
+    }
+    
+    func deleteAllImages() {
+        do {
+            let rows = try db.prepare(drafts)
+            for row in rows {
+                let image = try row.get(self.image)
+                if (image != "") {
+                    let imagePath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent(image)
+                    try FileManager.default.removeItem(atPath: imagePath.path)
+                }
+            }
+        } catch {
+            print("Error deleting images: \(error.localizedDescription)")
+        }
+    }
+
+    
     func deleteDraftsTable() {
         do {
             try db.run(drafts.drop(ifExists: true))

--- a/FoodBookApp/SQLite/DBManager.swift
+++ b/FoodBookApp/SQLite/DBManager.swift
@@ -20,7 +20,7 @@ class DBManager {
     private var waitTime: Expression<Int>!
     private var foodQuality: Expression<Int>!
     private var service: Expression<Int>!
-    //private var image: Expression<String?>!
+    private var image: Expression<String>!
     private var title: Expression<String>!
     private var content: Expression<String>!
     private var upload: Expression<Bool>!
@@ -40,13 +40,13 @@ class DBManager {
             waitTime = Expression<Int>("waitTime")
             foodQuality = Expression<Int>("foodQuality")
             service = Expression<Int>("service")
-            //image = Expreession<String?>("image")
+            image = Expression<String>("image")
             title = Expression<String>("title")
             content = Expression<String>("content")
             upload = Expression<Bool>("upload")
             
             if (!UserDefaults.standard.bool(forKey: "is_db_created")) {
-                //try db.run(drafts.drop(ifExists: true)) -> use when moifying table
+                //try db.run(drafts.drop(ifExists: true)) -> use when modifying table
                 try db.run(drafts.create { (t) in
                     t.column(spot, primaryKey: true)
                     t.column(cat1)
@@ -56,7 +56,7 @@ class DBManager {
                     t.column(waitTime)
                     t.column(foodQuality)
                     t.column(service)
-                    //t.column(image)
+                    t.column(image)
                     t.column(title)
                     t.column(content)
                     t.column(upload)
@@ -72,11 +72,11 @@ class DBManager {
     //(C)RUD
     public func addDraft(spotValue: String, cat1Value: String, cat2Value: String, cat3Value: String,
                          cleanlinessValue: Int, waitTimeValue: Int, foodQualityValue: Int, serviceValue: Int,
-                         titleValue: String, contentValue: String, uploadValue: Bool) {
+                         imageValue: String, titleValue: String, contentValue: String, uploadValue: Bool) {
         do {
             try db.run(drafts.insert(spot <- spotValue, cat1 <- cat1Value, cat2 <- cat2Value, cat3 <- cat3Value,
                                      cleanliness <- cleanlinessValue, waitTime <- waitTimeValue, foodQuality <- foodQualityValue,
-                                     service <- serviceValue, title <- titleValue, content <- contentValue, upload <- uploadValue))
+                                     service <- serviceValue, image <- imageValue, title <- titleValue, content <- contentValue, upload <- uploadValue))
             print("Draft added for spot \(spotValue)")
         } catch {
             print(error.localizedDescription)
@@ -101,19 +101,20 @@ class DBManager {
     func getDraft(spot: String) -> ReviewDraft? {
         do {
             if let row = try db.pluck(drafts.filter(self.spot == spot)) {
-                let content = try row.get(self.content)
                 let cleanliness = try row.get(self.cleanliness)
                 let foodQuality = try row.get(self.foodQuality)
                 let service = try row.get(self.service)
                 let waitTime = try row.get(self.waitTime)
                 let selectedCategories = [try row.get(self.cat1), try row.get(self.cat2), try row.get(self.cat3)]
-                let title = try row.get(self.title)
                 let reviewStats = ReviewDraftStats(cleanliness: cleanliness, foodQuality: foodQuality, service: service, waitTime: waitTime)
+                let image = try row.get(self.image)
+                let title = try row.get(self.title)
+                let content = try row.get(self.content)
                 let upload = try row.get(self.upload)
                 
                 print("Draft retrieved")
                 
-                return ReviewDraft(content: content, ratings: reviewStats, selectedCategories: selectedCategories, title: title, upload: upload)
+                return ReviewDraft(selectedCategories: selectedCategories, ratings: reviewStats, image: image, title: title, content: content, upload: upload)
             }
         } catch {
             print("Error retrieving draft: \(error.localizedDescription)")

--- a/FoodBookApp/UI/Views/CreateReview/CreateReview1View.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview1View.swift
@@ -23,6 +23,7 @@ struct CreateReview1View: View {
     @State private var waitingTime = 0
     @State private var foodQuality = 0
     @State private var service = 0
+    @State private var selectedImage: UIImage?
     @State private var title = ""
     @State private var content = ""
     
@@ -62,8 +63,18 @@ struct CreateReview1View: View {
                                     if (DBManager().draftExists(spot: spotId)) {
                                         DBManager().deleteDraft(spot: spotId)
                                     }
-                                    DBManager().addDraft(spotValue: spotId, cat1Value: selectedCats.indices.contains(0) ? selectedCats[0] : "", cat2Value: selectedCats.indices.contains(1) ? selectedCats[1] : "", cat3Value: selectedCats.indices.contains(2) ? selectedCats[2] : "", cleanlinessValue: cleanliness, waitTimeValue: waitingTime, foodQualityValue: foodQuality, serviceValue: service, titleValue: title, contentValue: content, uploadValue: false)
+                                    let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("\(spotId).jpg") //TODO: file name should be something i can twell has been changed
+                                    DBManager().addDraft(spotValue: spotId, cat1Value: selectedCats.indices.contains(0) ? selectedCats[0] : "", cat2Value: selectedCats.indices.contains(1) ? selectedCats[1] : "", cat3Value: selectedCats.indices.contains(2) ? selectedCats[2] : "", cleanlinessValue: cleanliness, waitTimeValue: waitingTime, foodQualityValue: foodQuality, serviceValue: service, imageValue: selectedImage != nil ? path.path : "", titleValue: title, contentValue: content, uploadValue: false)
                                     isNewReviewSheetPresented.toggle()
+                                    if selectedImage != nil {
+                                        do {
+                                            try self.selectedImage?.jpegData(compressionQuality: 1)?.write(to: path)
+                                            print(path.path)
+                                        }
+                                        catch {
+                                            print("Error saving image: \(error.localizedDescription)")
+                                        }
+                                    }
                                 }
                             )
                         }
@@ -79,7 +90,7 @@ struct CreateReview1View: View {
                                 Alert(title: Text("Try again"), message: Text("Please select at least one category"), dismissButton: .default(Text("OK")))
                             }
                         } else {
-                            NavigationLink(destination: CreateReview2View(categories: self.selectedCats, spotId: spotId, draftMode: draftMode, cleanliness: $cleanliness, waitingTime: $waitingTime, foodQuality: $foodQuality, service: $service, title: $title, content: $content, isNewReviewSheetPresented: $isNewReviewSheetPresented)) {
+                            NavigationLink(destination: CreateReview2View(categories: self.selectedCats, spotId: spotId, draftMode: draftMode, selectedImage: $selectedImage, cleanliness: $cleanliness, waitingTime: $waitingTime, foodQuality: $foodQuality, service: $service, title: $title, content: $content, isNewReviewSheetPresented: $isNewReviewSheetPresented)) {
                                 Text("Next")
                             }
                         }
@@ -159,7 +170,9 @@ struct CreateReview1View: View {
                 waitingTime = draft.ratings.waitTime
                 foodQuality = draft.ratings.foodQuality
                 service = draft.ratings.service
-                //TODO: image
+                if (draft.image != "") {
+                    selectedImage = UIImage(contentsOfFile: draft.image)
+                }
                 title = draft.title
                 content = draft.content
             }
@@ -169,7 +182,7 @@ struct CreateReview1View: View {
                 waitingTime = 0
                 foodQuality = 0
                 service = 0
-                //TODO: image
+                selectedImage = nil
                 title = ""
                 content = ""
             }

--- a/FoodBookApp/UI/Views/CreateReview/CreateReview2View.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview2View.swift
@@ -13,7 +13,7 @@ struct CreateReview2View: View {
     let categories: [String]
     let spotId: String
     var draftMode: Bool
-    @State private var selectedImage: UIImage? // TODO: binding for local storage
+    @Binding var selectedImage: UIImage? // TODO: binding for local storage
     @State private var showSheet: Bool = false
     @State private var showImagePicker: Bool = false
     @State private var sourceType: UIImagePickerController.SourceType = .camera
@@ -269,5 +269,5 @@ struct CreateReview2View: View {
 }
 
 #Preview {
-    CreateReview2View(categories: ["Homemade", "Colombian"], spotId: "ms1hTTxzVkiJElZiYHAT", draftMode: false, cleanliness: .constant(0), waitingTime: .constant(0), foodQuality: .constant(0), service: .constant(0), title: .constant(""), content: .constant(""), isNewReviewSheetPresented: .constant(true))
+    CreateReview2View(categories: ["Homemade", "Colombian"], spotId: "ms1hTTxzVkiJElZiYHAT", draftMode: false, selectedImage: .constant(nil), cleanliness: .constant(0), waitingTime: .constant(0), foodQuality: .constant(0), service: .constant(0), title: .constant(""), content: .constant(""), isNewReviewSheetPresented: .constant(true))
 }

--- a/FoodBookApp/UI/Views/CreateReview/CreateReview2View.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview2View.swift
@@ -13,11 +13,11 @@ struct CreateReview2View: View {
     let categories: [String]
     let spotId: String
     var draftMode: Bool
-    @Binding var selectedImage: UIImage? // TODO: binding for local storage
+    @Binding var imageChange: Bool
+    @Binding var selectedImage: UIImage?
     @State private var showSheet: Bool = false
     @State private var showImagePicker: Bool = false
     @State private var sourceType: UIImagePickerController.SourceType = .camera
-    @State private var imageIsSelected: Bool = false
     @Binding var cleanliness: Int
     @Binding var waitingTime: Int
     @Binding var foodQuality: Int
@@ -133,6 +133,7 @@ struct CreateReview2View: View {
                                             let reviewId = try await model.addReview(review: newReview)
                                             try await model.addReviewToSpot(spotId: spotId, reviewId: reviewId)
                                             if (DBManager().draftExists(spot: spotId) && draftMode) {
+                                                DBManager().deleteImage(spot: spotId)
                                                 DBManager().deleteDraft(spot: spotId)
                                             }
                                             print("The review uploaded has this ID:", reviewId)
@@ -176,7 +177,7 @@ struct CreateReview2View: View {
                 }
                 
                 // Add or remove photo button
-                if !imageIsSelected {
+                if selectedImage == nil {
                     addPhotoButton.padding()
                 }
                 else {
@@ -225,11 +226,8 @@ struct CreateReview2View: View {
             ImagePicker(image: self.$selectedImage, isShown: self.$showImagePicker, sourceType: self.sourceType)
         }.onChange(of: selectedImage) {
             Task {
-                if imageIsSelected {
-                    imageIsSelected = false
-                }
-                else {
-                    imageIsSelected = true
+                if (draftMode) {
+                    imageChange = true
                 }
             }
         }.alert("Try again", isPresented: $showAlert) {
@@ -269,5 +267,5 @@ struct CreateReview2View: View {
 }
 
 #Preview {
-    CreateReview2View(categories: ["Homemade", "Colombian"], spotId: "ms1hTTxzVkiJElZiYHAT", draftMode: false, selectedImage: .constant(nil), cleanliness: .constant(0), waitingTime: .constant(0), foodQuality: .constant(0), service: .constant(0), title: .constant(""), content: .constant(""), isNewReviewSheetPresented: .constant(true))
+    CreateReview2View(categories: ["Homemade", "Colombian"], spotId: "ms1hTTxzVkiJElZiYHAT", draftMode: false, imageChange: .constant(false), selectedImage: .constant(nil), cleanliness: .constant(0), waitingTime: .constant(0), foodQuality: .constant(0), service: .constant(0), title: .constant(""), content: .constant(""), isNewReviewSheetPresented: .constant(true))
 }

--- a/FoodBookApp/UI/Views/User/UserView.swift
+++ b/FoodBookApp/UI/Views/User/UserView.swift
@@ -77,6 +77,7 @@ struct UserView: View {
                         do {
                             print("signing out...")
                             try AuthService.shared.signOut()
+                            DBManager().deleteAllImages()
                             DBManager().deleteDraftsTable() //TODO: maybe show alert notifying user?
                             NotificationHandler().cancelNotification(identifier: "lastReviewNotification")
                             dismiss()


### PR DESCRIPTION
- Closes #84 
- Creates a local copy of an image for review draft with FileManager
- Deletes all images stored if user logs out
- 🚨 To test on your phone/simulator, please **log out** so DB can be created again (the DB is used to store the image path)
- In the next comment you'll see a ss of the review uploaded
- This concludes my local storage feature

Lmk if you have any questions or want changes made

https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/71bf446e-dd97-45f7-9e85-082a5cdf2029

