### PR TITLE
[FIX] Draft can be created with just the image

### DIFF
--- a/FoodBookApp/UI/Views/CreateReview/CreateReview1View.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview1View.swift
@@ -38,12 +38,12 @@ struct CreateReview1View: View {
                     // Header
                     HStack{
                         TextButton(text: "Cancel", txtSize: 17, hPadding: 0, action: {
-                            if (!selectedCats.isEmpty || cleanliness > 0 || waitingTime > 0 || foodQuality > 0 || service > 0 || !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                            if (!selectedCats.isEmpty || cleanliness > 0 || waitingTime > 0 || foodQuality > 0 || service > 0 || !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || selectedImage != nil) {
                                 
                                 let filteredCats = draft?.selectedCategories.filter { !$0.isEmpty }
                                 
                                 if (filteredCats != selectedCats || draft?.ratings.cleanliness != cleanliness || draft?.ratings.foodQuality != foodQuality || draft?.ratings.waitTime != waitingTime
-                                    || draft?.ratings.service != service || imageChange || draft?.title != title || draft?.content != content) {
+                                    || draft?.ratings.service != service || ((draftMode && imageChange) || (!draftMode && selectedImage != nil)) || draft?.title != title || draft?.content != content) {
                                     showDraftAlert.toggle()
                                 }
                                 else {


### PR DESCRIPTION
- Closes #105 
- Now you can have a draft w/ just the image. However, remember that to access the view with the image if you have to select a category.

Lmk if you have any questions or want changes made

https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/ad85c338-f190-4694-ad13-56c7f4607357
