### PR TITLE
[FIX] Fetch categories when fetching spot

### DIFF
--- a/FoodBookApp/UI/Views/CreateReview/CreateReview1View.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview1View.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct CreateReview1View: View {
     var spotId: String
     var spotName: String
+    var categories: [String]
     var draft: ReviewDraft?
     var draftMode: Bool
     @State private var model = CreateReview1ViewModel()
@@ -172,8 +173,6 @@ struct CreateReview1View: View {
                         Spacer()
                     }
                     
-                }.task {
-                    _ = try? await model.fetchCategories()
                 }
             }
         }
@@ -217,9 +216,9 @@ struct CreateReview1View: View {
     
     var searchResults: [String] {
         if searchText.isEmpty {
-            return model.categories
+            return categories
         } else {
-            return model.categories.filter { cat in
+            return categories.filter { cat in
                 cat.localizedCaseInsensitiveContains(searchText)
             }
         }
@@ -227,5 +226,5 @@ struct CreateReview1View: View {
 }
 
 #Preview {
-    CreateReview1View(spotId: "ms1hTTxzVkiJElZiYHAT", spotName: "Mi Caserito", draftMode: false, isNewReviewSheetPresented: .constant(true))
+    CreateReview1View(spotId: "ms1hTTxzVkiJElZiYHAT", spotName: "Mi Caserito", categories: ["Homemade", "Colombian"], draftMode: false, isNewReviewSheetPresented: .constant(true))
 }

--- a/FoodBookApp/UI/Views/CreateReview/CreateReview1ViewModel.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview1ViewModel.swift
@@ -10,16 +10,11 @@ import Observation
 
 @Observable
 class CreateReview1ViewModel {
-    var categories: [String] = []
     
-    private let categoryRepository: CategoryRepository = CategoryRepositoryImpl.shared
     private let unfinishedReviewRepository: UnfinishedReviewRepository = UnfinishedReviewRepositoryImpl.shared
     private let utils = Utils.shared
     
     @MainActor
-    func fetchCategories() async throws {
-        self.categories = try await categoryRepository.getCategories()
-    }
     
     func increaseUnfinishedReviewCount(spot: String) async throws {
         try await unfinishedReviewRepository.updateUnfinishedReviewCount(spot: spot)

--- a/FoodBookApp/UI/Views/SpotDetail/SpotDetailView.swift
+++ b/FoodBookApp/UI/Views/SpotDetail/SpotDetailView.swift
@@ -166,6 +166,7 @@ struct SpotDetailView: View {
             isLoading = true
             Task {
                 _ = try? await model.fetchSpot(spotId: spotId)
+                _ = try? await model.fetchCategories()
                 isLoading = false
             }
         }
@@ -178,7 +179,7 @@ struct SpotDetailView: View {
         .sheet(
             isPresented: $isNewReviewSheetPresented,
             content: {
-                CreateReview1View(spotId: spotId, spotName: model.spot.name, draft: draft, draftMode: draftMode, isNewReviewSheetPresented: $isNewReviewSheetPresented)
+                CreateReview1View(spotId: spotId, spotName: model.spot.name, categories: model.categories, draft: draft, draftMode: draftMode, isNewReviewSheetPresented: $isNewReviewSheetPresented)
             })
     }
 }

--- a/FoodBookApp/UI/Views/SpotDetail/SpotDetailViewModel.swift
+++ b/FoodBookApp/UI/Views/SpotDetail/SpotDetailViewModel.swift
@@ -12,18 +12,24 @@ import FirebaseFirestore
 @Observable
 class SpotDetailViewModel {
     
+    var categories: [String] = []
     
     var spot: Spot = Spot(categories: [], location: GeoPoint(latitude: 0, longitude: 0), name: "", price: "", waitTime: WaitTime(min: 0, max: 5), reviewData: ReviewData(stats: SpotStats(cleanliness: 5, foodQuality: 5, service: 5, waitTime: 5), userReviews: []), imageLinks: [])
     
     var ratings: [String: Double] = ["Cleanliness": 0, "Waiting time": 0, "Service": 0, "Food quality": 0]
     
-    private let repository: SpotRepository = SpotRepositoryImpl.shared
+    private let spotRepository: SpotRepository = SpotRepositoryImpl.shared
+    private let categoryRepository: CategoryRepository = CategoryRepositoryImpl.shared
     
     init() {}
     
     @MainActor
     func fetchSpot(spotId: String) async throws {
-        self.spot = try await repository.getSpotById(docId: spotId)
+        self.spot = try await spotRepository.getSpotById(docId: spotId)
         self.ratings = ["Cleanliness": self.spot.reviewData.stats.cleanliness / 5,"Waiting Time": self.spot.reviewData.stats.waitTime / 5,"Service": self.spot.reviewData.stats.service / 5,"Food quality": self.spot.reviewData.stats.foodQuality / 5]
+    }
+    
+    func fetchCategories() async throws {
+        self.categories = try await categoryRepository.getCategories()
     }
 }


### PR DESCRIPTION
- Closes #109 
- The fetch for the categories is now done while also fetching a spot's detail, which allows users to start a review without having to wait for the categories to load.

Lmk if you have any questions or want changes made

https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/d301972c-1612-410e-9c12-20bdfccb9e48