### PR TITLE
[FIX] Update cache on bookmarks tap (not on ID fetch)

### DIFF
--- a/FoodBookApp/UI/Components/SpotCard.swift
+++ b/FoodBookApp/UI/Components/SpotCard.swift
@@ -18,6 +18,7 @@ struct SpotCard: View {
     let categories : [Category]
     let imageLinks : [String]
     let price : String
+    let spot: Spot?
     
     let rowLayout = Array(repeating: GridItem(), count: 2)
     
@@ -46,7 +47,7 @@ struct SpotCard: View {
                 Spacer()
                 Button(action: {
                     
-                    bookmarksManager.updateBookmarks(spotId: id)
+                    bookmarksManager.updateBookmarks(spot: spot!)
                 }, label: {
                     Image(systemName: bookmarksManager.containsId(spotId: id) ? "bookmark.fill" : "bookmark").imageScale(.large).bold()
                 })
@@ -85,7 +86,7 @@ struct SpotCard: View {
             "https://images.unsplash.com/photo-1476224203421-9ac39bcb3327?q=80&w=2370&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
             "https://images.unsplash.com/photo-1529042410759-befb1204b468?q=80&w=2486&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
         ],
-        price: "$"
-        
+        price: "$",
+        spot: nil
     )
 }

--- a/FoodBookApp/UI/Views/Bookmarks/BookmarksView.swift
+++ b/FoodBookApp/UI/Views/Bookmarks/BookmarksView.swift
@@ -44,7 +44,8 @@ struct BookmarksView: View {
                                 distance: spot.distance ?? "-",
                                 categories: Array(Utils.shared.highestCategories(spot: spot).prefix(5)),
                                 imageLinks: spot.imageLinks ?? [],
-                                price: spot.price
+                                price: spot.price,
+                                spot: spot
                             )
                             .fixedSize(horizontal: false, vertical: true)
                             .accentColor(.black)
@@ -57,6 +58,15 @@ struct BookmarksView: View {
                 isFetching = true
                 await model.fetchSpots(Array(bookmarksManager.savedBookmarkIds))
                 isFetching = false
+            }
+            .onReceive(NetworkService.shared.$isOnline) { isOnline in
+                if model.spots.isEmpty && isOnline {
+                    print("Spots is empty but online, retrying...")
+                    Task {
+                        await model.fetchSpots(Array(bookmarksManager.savedBookmarkIds))
+                    }
+                }
+                
             }
         }
     }

--- a/FoodBookApp/UI/Views/Bookmarks/BookmarksViewModel.swift
+++ b/FoodBookApp/UI/Views/Bookmarks/BookmarksViewModel.swift
@@ -28,10 +28,13 @@ final class BookmarksViewModel {
             spots = cachedSpots as! [Spot]
         } else {
             do {
-                spots = try await self.repository.getSpotsWithIDList(list: spotIds)
-                 bookmarksCache.setObject(spots as NSArray, forKey: cacheKey)
+                if NetworkService.shared.isOnline {
+                    print("Fetching from firebase...")
+                    spots = try await self.repository.getSpotsWithIDList(list: spotIds)
+                    bookmarksCache.setObject(spots as NSArray, forKey: cacheKey)
+                }
             } catch {
-                print(error)
+                print("[Bookmarks] Fetching error: ", error)
             }
         }
         

--- a/FoodBookApp/UI/Views/Browse/BrowseView.swift
+++ b/FoodBookApp/UI/Views/Browse/BrowseView.swift
@@ -31,7 +31,8 @@ struct BrowseView: View {
                                 distance: spot.distance ?? "-",
                                 categories: Array(Utils.shared.highestCategories(spot: spot).prefix(5)),
                                 imageLinks: spot.imageLinks ?? [],
-                                price: spot.price
+                                price: spot.price,
+                                spot: spot
                             )
                             .fixedSize(horizontal: false, vertical: true)
                             .accentColor(.black)

--- a/FoodBookApp/UI/Views/ForYou/ForYouView.swift
+++ b/FoodBookApp/UI/Views/ForYou/ForYouView.swift
@@ -36,7 +36,8 @@ struct ForYouView: View {
                                 distance: spot.distance ?? "-",
                                 categories: spot.categories,
                                 imageLinks: spot.imageLinks ?? [],
-                                price: spot.price
+                                price: spot.price,
+                                spot: spot
                             )
                             .fixedSize(horizontal: false, vertical: true)
                         }


### PR DESCRIPTION
* When saving (or removing) a bookmark, the cache is updated at that moment. 
* This means that even if the user is offline, they can still update their list from other views and the corresponding Spots will still be shown on the bookmarks view

https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/61592394/979826d4-50ff-44aa-9458-50fe689fefc5

