### PR TITLE
[FEATURE] Add timeout to login flow (once in the browser) using multi-threading

### DIFF
--- a/FoodBookApp/UI/Views/Login/LoginView.swift
+++ b/FoodBookApp/UI/Views/Login/LoginView.swift
@@ -18,6 +18,7 @@ struct LoginView: View {
     @Binding var showSignInView: Bool
     @ObservedObject var locationService = LocationService.shared
     @ObservedObject var networkService = NetworkService.shared
+    @State var signINAAA = SignInGoogleHelper.shared
     
     let notify = NotificationHandler()
     
@@ -25,7 +26,7 @@ struct LoginView: View {
     var body: some View {
         VStack {
             
-            // Application Name
+            // MARK: Application Name
             HStack {
                 Text("foodbook")
                     .font(.custom("ArchivoBlack-Regular", size: 48))
@@ -34,13 +35,13 @@ struct LoginView: View {
                 Spacer()
             }
             
-            // Welcome page logo
+            // MARK: Welcome page logo
             Image("toasty")
                 .resizable()
                 .scaledToFit()
                 .padding()
             
-            // Application Tagline
+            // MARK: Application Tagline
             HStack{
                 Text("Where good people find good food.") // TODO: i18n string
                     .font(.system(size: 30, weight: .regular, design: .default))
@@ -50,7 +51,7 @@ struct LoginView: View {
             }
             .padding(.bottom, 30)
             
-            // Button to log in
+            // MARK: Button to log in
             GoogleSignInButton(viewModel: GoogleSignInButtonViewModel(scheme: .dark, style: .wide, state: .normal)) {
                 Task {
                     await viewModel.signInGoogle()
@@ -76,6 +77,13 @@ struct LoginView: View {
                 Button("OK", role: .cancel) { }
             } message: {
                 Text(viewModel.errorMsg)
+            }
+            .alert("Timeout occured.", isPresented: Binding<Bool>(get: { self.signINAAA.timeoutComplete && !self.signINAAA.flowComplete }, set: { _ in })) {
+                Button("OK", role: .cancel) {
+                    signINAAA.timeoutComplete = false
+                }
+            } message: {
+                Text("You took to long to sign-in and no answer was received, check your internet connection and try again.")
             }
             
             if(networkService.isUnavailable) {

--- a/FoodBookApp/UI/Views/Login/LoginViewModel.swift
+++ b/FoodBookApp/UI/Views/Login/LoginViewModel.swift
@@ -9,7 +9,6 @@ import Foundation
 import FirebaseAuth
 import GoogleSignIn
 
-@MainActor
 @Observable 
 final class LoginViewModel {
     
@@ -17,8 +16,9 @@ final class LoginViewModel {
     var errorTitle: String = ""
     var errorMsg: String = ""
     
+    
     func signInGoogle() async {
-        let helper = SignInGoogleHelper()
+        let helper = SignInGoogleHelper.shared
         
         do {
             let tokens = try await helper.signIn()
@@ -27,8 +27,7 @@ final class LoginViewModel {
             errorTitle = "No answer recieved"
             errorMsg = "Seems like you took to long to sign-in, check your internet connection and try again."
             showAlert = true
-        }
-        catch GIDSignInError.canceled {
+        } catch GIDSignInError.canceled {
             errorTitle = "Canceled Sign-in"
             errorMsg = "You canceled the sign-in flow. If you wish to sign in, press the button again and complete the authentication."
             showAlert = true


### PR DESCRIPTION
* If a user takes longer than 45 seconds to complete the sign in flow (for example if they are signing in and connection is to slow for google to processes it) then the view google's UI is shown is dismissed and a message is shown (completes and closes #115)
* Solution was a combination of threading, GCD and Observable objects/variable

Demo video with happy path, cancel path (or any other error that is caught in the VM) and timeout path below: 

https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/61592394/9ef4f2d2-7843-4c6d-90de-064fc60bc0ae

Note for the demo timeout was to set to 5 seconds, in the PR it has the 45 mentioned above