### PR TITLE
[FEATURE] EC: spot detail, reviews and leave review + cache fix

### DIFF
--- a/FoodBookApp.xcodeproj/project.pbxproj
+++ b/FoodBookApp.xcodeproj/project.pbxproj
@@ -966,7 +966,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"FoodBookApp/Preview Content\"";
-				DEVELOPMENT_TEAM = AX26HDBNSN;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoodBookApp/Info.plist;
@@ -986,7 +986,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp.laura;
+				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -1002,7 +1002,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"FoodBookApp/Preview Content\"";
-				DEVELOPMENT_TEAM = AX26HDBNSN;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoodBookApp/Info.plist;
@@ -1022,7 +1022,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp.laura;
+				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/FoodBookApp.xcodeproj/project.pbxproj
+++ b/FoodBookApp.xcodeproj/project.pbxproj
@@ -966,7 +966,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"FoodBookApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = AX26HDBNSN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoodBookApp/Info.plist;
@@ -986,7 +986,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp;
+				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp.laura;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -1002,7 +1002,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"FoodBookApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = AX26HDBNSN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoodBookApp/Info.plist;
@@ -1022,7 +1022,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp;
+				PRODUCT_BUNDLE_IDENTIFIER = Team23.FoodBookApp.laura;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/FoodBookApp/Models/Cache/HardcodedSpots.swift
+++ b/FoodBookApp/Models/Cache/HardcodedSpots.swift
@@ -41,12 +41,7 @@ class HardcodedSpots {
                                                      service: 3.6363636363636362,
                                                      waitTime: 3.0909090909090904),
              userReviews: []), // TODO: add reviews? at least show offline ReviewsView
-             imageLinks: ["https://static.thenounproject.com/png/944120-200.png",
-                          "https://static.thenounproject.com/png/944120-200.png",
-                          "https://static.thenounproject.com/png/944120-200.png",
-                          "https://static.thenounproject.com/png/944120-200.png",
-                          "https://static.thenounproject.com/png/944120-200.png",
-                          "https://static.thenounproject.com/png/944120-200.png"]),
+             imageLinks: ["", "", "", "", "", ""]),
         Spot(id: "NJRaBUfiBlNk9v5hsb7D",
              categories: [
                 Category(name: "sandwhich", count: 1),
@@ -67,12 +62,7 @@ class HardcodedSpots {
                                                      service: 4.111111111111112,
                                                      waitTime: 3.7777777777777777),
              userReviews: []), // TODO: add reviews? at least show offline ReviewsView
-             imageLinks: ["https://static.thenounproject.com/png/944120-200.png",
-                          "https://static.thenounproject.com/png/944120-200.png",
-                          "https://static.thenounproject.com/png/944120-200.png",
-                          "https://static.thenounproject.com/png/944120-200.png",
-                          "https://static.thenounproject.com/png/944120-200.png",
-                          "https://static.thenounproject.com/png/944120-200.png"])
+             imageLinks: ["", "", "", "", "", ""])
         // Add more spots as needed
     ]
 }

--- a/FoodBookApp/UI/Views/Content/ContentViewModel.swift
+++ b/FoodBookApp/UI/Views/Content/ContentViewModel.swift
@@ -15,7 +15,7 @@ class ContentViewModel {
     
     private init() {}
     
-    var browseSpots: [Spot] = HardcodedSpots.shared.spots
+    var browseSpots: [Spot] = []
     var forYouSpots: [Spot] = []
     
     var browseSpotsCached: [Spot] = HardcodedSpots.shared.spots

--- a/FoodBookApp/UI/Views/Content/ContentViewModel.swift
+++ b/FoodBookApp/UI/Views/Content/ContentViewModel.swift
@@ -15,7 +15,7 @@ class ContentViewModel {
     
     private init() {}
     
-    var browseSpots: [Spot] = []
+    var browseSpots: [Spot] = HardcodedSpots.shared.spots
     var forYouSpots: [Spot] = []
     
     var browseSpotsCached: [Spot] = HardcodedSpots.shared.spots
@@ -76,9 +76,9 @@ class ContentViewModel {
     
     func fallback() {
 //        print("SPOTS: Before fallback: \(self.browseSpots.count)")
-        self.browseSpotsCached = cacheService.getSpots() ?? []
+        self.browseSpotsCached = cacheService.getSpots() ?? HardcodedSpots.shared.spots
 //        print("SPOTS: After fallback: \(self.browseSpots.count)")
-        self.forYouSpotsCached = cacheService.getForYou() ?? []
+        self.forYouSpotsCached = cacheService.getForYou() ?? HardcodedSpots.shared.spots
 
     }
 

--- a/FoodBookApp/UI/Views/SpotDetail/SpotDetailView.swift
+++ b/FoodBookApp/UI/Views/SpotDetail/SpotDetailView.swift
@@ -166,7 +166,7 @@ struct SpotDetailView: View {
                                         .cornerRadius(12)
                                         .font(.system(size: 20))
                                 }).padding().alert(isPresented: $showNoConnectionAlert) {
-                                    Alert(title: Text("No connection"), message: Text("You can only leave reviews while being connected, sorry!"), dismissButton: .default(Text("OK")))
+                                    Alert(title: Text("No connection"), message: Text("You can only leave reviews while being connected, please try again later!"), dismissButton: .default(Text("OK")))
                                 }
                             }.actionSheet(isPresented: $showDraftMenu) {
                                 ActionSheet(


### PR DESCRIPTION
- Closes #134 
- Adds eventual connectivity for a spot detail, specifically when a user opens this view w/o connection
- Adds alert when spot detail's info had been loaded but the user had no connection and attempts to leave a review
- Fixed browse spots cache edge cases (hopefully)

Lmk if you have any questions or want changes made

### 1. Navegation from browse to spot detail w/o connection
<img alt="case 1" height="400" src="https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/b4cd4bba-c90b-490d-86d6-e9bce6e16483">

### 2. Connection recovered
<img alt="case 2" height="400" src="https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/05f26393-1d2c-4a17-8f2d-5e136512721d">

### 3. Connection lost but data was loaded
<img alt="case 3" height="400" src="https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/92718287-60f1-4e6b-8745-d2274bfdf954">

### 4. Attempting to create review w/o connection
<img alt="case 4" height="400" src="https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/89ce1aac-5d9a-4946-b365-1a36c881ac8b">