### PR TITLE
[BUGFIX] EC reviews uploaded twice

### DIFF
--- a/FoodBookApp/UI/Components/SpotCard.swift
+++ b/FoodBookApp/UI/Components/SpotCard.swift
@@ -27,17 +27,25 @@ struct SpotCard: View {
     var body: some View {
         VStack(alignment: .leading) {
             LazyHGrid(rows: rowLayout, alignment: .top, spacing: 8, content: {
-                ForEach(imageLinks, id: \.self){
-                    image in
-                    AsyncImage(url: URL(string: image)) { image in
-                        image.resizable()
-                            .aspectRatio(contentMode: .fill)
-                    } placeholder: {
-                        ProgressView()
+                ForEach(imageLinks.indices, id: \.self){ index in
+                    let image = imageLinks[index]
+                    if image != "" {
+                        AsyncImage(url: URL(string: image)) { image in
+                            image.resizable()
+                                .aspectRatio(contentMode: .fill)
+                        } placeholder: {
+                            ProgressView()
+                        }
+                        .frame(width: 110, height: 80)
+                        .cornerRadius(10)
                     }
-                    .frame(width: 110, height: 80)
-                    .cornerRadius(10)
-                    
+                    else {
+                        Image("no-image")
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 110, height: 80)
+                            .cornerRadius(10)
+                    }
                 }
             })
             HStack {

--- a/FoodBookApp/UI/Views/Bookmarks/BookmarksView.swift
+++ b/FoodBookApp/UI/Views/Bookmarks/BookmarksView.swift
@@ -15,6 +15,8 @@ struct BookmarksView: View {
     @State private var model = BookmarksViewModel()
 
     @State private var isFetching = false // Track fetching status
+    
+    @ObservedObject var networkService = NetworkService.shared
 
     
     var body: some View {
@@ -25,6 +27,16 @@ struct BookmarksView: View {
                     .foregroundColor(/*@START_MENU_TOKEN@*/.blue/*@END_MENU_TOKEN@*/)
                     .font(.system(size: 100))
                 Text("You have no saved bookmarks.")
+            }.onAppear { // TODO: add this to other view maybe?
+                Task {
+                    do {
+                        if networkService.isOnline {
+                            try await DBManager().uploadReviews()
+                        }
+                    } catch {
+                        print("Error uploading reviews: ", error.localizedDescription)
+                    }
+                }
             }
         }
         else {
@@ -50,6 +62,16 @@ struct BookmarksView: View {
                             .fixedSize(horizontal: false, vertical: true)
                             .accentColor(.black)
                         }
+                    }
+                }
+            }.onAppear { // TODO: add this to other view maybe?
+                Task {
+                    do {
+                        if networkService.isOnline {
+                            try await DBManager().uploadReviews()
+                        }
+                    } catch {
+                        print("Error uploading reviews: ", error.localizedDescription)
                     }
                 }
             }

--- a/FoodBookApp/UI/Views/ForYou/ForYouView.swift
+++ b/FoodBookApp/UI/Views/ForYou/ForYouView.swift
@@ -56,6 +56,16 @@ struct ForYouView: View {
                     ProgressView()
                 }
             }
+        }.onAppear { // TODO: add this to other view maybe?
+            Task {
+                do {
+                    if networkService.isOnline {
+                        try await DBManager().uploadReviews()
+                    }
+                } catch {
+                    print("Error uploading reviews: ", error.localizedDescription)
+                }
+            }
         }
         .padding(8)
         

--- a/FoodBookApp/Utils/Utils.swift
+++ b/FoodBookApp/Utils/Utils.swift
@@ -77,7 +77,6 @@ final class Utils {
         }
     }
     
-
     func highestCategories(spot: Spot) -> [Category] {
         var sortedCategories = [Category]()
         let queue = DispatchQueue(label: "sortingQueue", attributes: .concurrent)


### PR DESCRIPTION
- Closes #148 
- EC reviews are uploaded when accessing the ForYou and Bookmarks views now, hopelly fixing the problem Boris found. Not entirely sure this is the solution bc I've tried to recreate the problem multiple times and nothing worked. The only thing I remember is that, before uploading the review, he was in the Bookmarks view, so that's why I coded this solution. If we somehow stumble upon the problem again, I'll open another issue
- This PR also changes the progress view in the hard coded spots to a static image.

Lmk if you have any questions or want changes made 

<img alt="hard coded spots static image" height="500" src="https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/3ebaae7d-0deb-495e-bdbb-519947df9be0">

