### PR TITLE
[FIX] Unfinished reviews id now spot id

### DIFF
--- a/FoodBookApp/Repositories/UnfinishedReview/UnfinishedReviewImpl.swift
+++ b/FoodBookApp/Repositories/UnfinishedReview/UnfinishedReviewImpl.swift
@@ -12,7 +12,7 @@ class UnfinishedReviewRepositoryImpl: UnfinishedReviewRepository {
     static var shared: UnfinishedReviewRepository = UnfinishedReviewRepositoryImpl()
     static var unfinishedReviewSA: UnfinishedReviewSA = UnfinishedReviewSAFirebase.shared
     
-    func updateUnfinishedReviewCount(spot: String) async throws {
-        return try await UnfinishedReviewRepositoryImpl.unfinishedReviewSA.updateUnfinishedReviewCount(spot: spot)
+    func updateUnfinishedReviewCount(spotId: String, spotName: String) async throws {
+        return try await UnfinishedReviewRepositoryImpl.unfinishedReviewSA.updateUnfinishedReviewCount(spotId: spotId, spotName: spotName)
     }
 }

--- a/FoodBookApp/Repositories/UnfinishedReview/UnfinishedReviewRepository.swift
+++ b/FoodBookApp/Repositories/UnfinishedReview/UnfinishedReviewRepository.swift
@@ -10,5 +10,5 @@ import SwiftUI
 
 protocol UnfinishedReviewRepository {
     static var unfinishedReviewSA: UnfinishedReviewSA { get }
-    func updateUnfinishedReviewCount(spot: String) async throws
+    func updateUnfinishedReviewCount(spotId: String, spotName: String) async throws
 }

--- a/FoodBookApp/ServiceAdapter/Firebase/UnfinishedReviewSAFirebase.swift
+++ b/FoodBookApp/ServiceAdapter/Firebase/UnfinishedReviewSAFirebase.swift
@@ -23,16 +23,17 @@ class UnfinishedReviewSAFirebase: UnfinishedReviewSA {
         self.collection = client.db.collection("unfinishedReviews")
     }
     
-    func updateUnfinishedReviewCount(spot: String) async throws {
+    func updateUnfinishedReviewCount(spotId: String, spotName: String) async throws {
         do {
-            let querySnapshot = try await collection.whereField("spot", isEqualTo: spot).getDocuments()
-        
-            if querySnapshot.documents.isEmpty {
-                try await collection.addDocument(data: ["spot": spot, "count": 1])
+            let documentRef = collection.document(spotId)
+            
+            let documentSnapshot = try await documentRef.getDocument()
+            
+            if !documentSnapshot.exists {
+                try await documentRef.setData(["spot": spotName, "count": 1])
             } else {
-                let document = querySnapshot.documents[0]
-                let count = document.data()["count"] as? Int ?? 0
-                try await document.reference.updateData(["count": count + 1])
+                let count = documentSnapshot.data()?["count"] as? Int ?? 0
+                try await documentRef.updateData(["count": count + 1])
             }
         } catch {
             throw error

--- a/FoodBookApp/ServiceAdapter/UnfinishedReviewSA.swift
+++ b/FoodBookApp/ServiceAdapter/UnfinishedReviewSA.swift
@@ -9,5 +9,5 @@ import Foundation
 
 protocol UnfinishedReviewSA {
     static var shared: UnfinishedReviewSA { get }
-    func updateUnfinishedReviewCount(spot: String) async throws
+    func updateUnfinishedReviewCount(spotId: String, spotName: String) async throws
 }

--- a/FoodBookApp/UI/Views/CreateReview/CreateReview1View.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview1View.swift
@@ -200,7 +200,7 @@ struct CreateReview1View: View {
             if (shouldCount && ((!draftMode && (!selectedCats.isEmpty || cleanliness > 0 || waitingTime > 0 || foodQuality > 0 || service > 0 || !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || selectedImage != nil)) || (draftMode && (filteredCats != selectedCats || draft?.ratings.cleanliness != cleanliness || draft?.ratings.foodQuality != foodQuality || draft?.ratings.waitTime != waitingTime || draft?.ratings.service != service || imageChange || draft?.title != title || draft?.content != content)))) {
                 Task {
                     do {
-                        try await model.increaseUnfinishedReviewCount(spot: spotName)
+                        try await model.increaseUnfinishedReviewCount(spotId: spotId, spotName: spotName)
                     } catch {
                         print("Error increasing unfinished review count: \(error.localizedDescription)")
                     }

--- a/FoodBookApp/UI/Views/CreateReview/CreateReview1ViewModel.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview1ViewModel.swift
@@ -16,7 +16,7 @@ class CreateReview1ViewModel {
     
     @MainActor
     
-    func increaseUnfinishedReviewCount(spot: String) async throws {
-        try await unfinishedReviewRepository.updateUnfinishedReviewCount(spot: spot)
+    func increaseUnfinishedReviewCount(spotId: String, spotName: String) async throws {
+        try await unfinishedReviewRepository.updateUnfinishedReviewCount(spotId: spotId, spotName: spotName)
     }
 }


### PR DESCRIPTION
- Closes #161 
- The id in for an unfinished review doc is now the same as the spot it's referecing

Lmk if you have any questions or want changes made

**Unfinished reviews collection:**

<img alt="unifinished reviews collection" height="300" src="https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/7463d621-adda-48bc-94e2-b6b04c3fa7d5">

**Spots collection:**

<img alt="spots collection" height="300" src="https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/11aab247-8064-49df-b6a1-ae45065f4b00">