### PR TITLE
[FIX] Notification permission timing

### DIFF
--- a/FoodBookApp/FoodBookApp.swift
+++ b/FoodBookApp/FoodBookApp.swift
@@ -25,7 +25,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
             self.handleTask(task: task)
         }
                 
-        notify.askPermission() // Here to handle case when deleting and re-downloading app
+        notify.askPermission()
         
         return true
     }

--- a/FoodBookApp/FoodBookApp.swift
+++ b/FoodBookApp/FoodBookApp.swift
@@ -11,6 +11,7 @@ import BackgroundTasks
 
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     let taskId = "Team23.FoodBookApp.contextTask"
+    let notify = NotificationHandler()
 
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
@@ -24,7 +25,12 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
             self.handleTask(task: task)
         }
         
+        let signedIn: Bool = {
+            let authUser = try? AuthService.shared.getAuthenticatedUser()
+            return authUser != nil
+        }()
         
+        notify.askPermission() // Here to handle case when deleting and re-downloading app
         
         return true
     }

--- a/FoodBookApp/FoodBookApp.swift
+++ b/FoodBookApp/FoodBookApp.swift
@@ -24,12 +24,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
             guard let task = task as? BGAppRefreshTask else { return }
             self.handleTask(task: task)
         }
-        
-        let signedIn: Bool = {
-            let authUser = try? AuthService.shared.getAuthenticatedUser()
-            return authUser != nil
-        }()
-        
+                
         notify.askPermission() // Here to handle case when deleting and re-downloading app
         
         return true

--- a/FoodBookApp/Handlers/NotificationHandler.swift
+++ b/FoodBookApp/Handlers/NotificationHandler.swift
@@ -15,7 +15,6 @@ class NotificationHandler {
         { success, error in
             if success {
                 print("Access granted!")
-                self.sendLastReviewNotification(date: Date())
             } else if let error = error {
                 print(error.localizedDescription)
             }

--- a/FoodBookApp/Handlers/NotificationHandler.swift
+++ b/FoodBookApp/Handlers/NotificationHandler.swift
@@ -15,6 +15,7 @@ class NotificationHandler {
         { success, error in
             if success {
                 print("Access granted!")
+                self.sendLastReviewNotification(date: Date())
             } else if let error = error {
                 print(error.localizedDescription)
             }
@@ -37,6 +38,7 @@ class NotificationHandler {
                 
         let content = UNMutableNotificationContent()
         content.title = "We miss you..."
+        // FIXME: You haven't left a review in X days, depending on settings
         content.body = "You haven't left a review in a while"
         content.sound = UNNotificationSound.default
         

--- a/FoodBookApp/UI/Views/Login/LoginView.swift
+++ b/FoodBookApp/UI/Views/Login/LoginView.swift
@@ -20,9 +20,6 @@ struct LoginView: View {
     @ObservedObject var networkService = NetworkService.shared
     @State var signINAAA = SignInGoogleHelper.shared
     
-    let notify = NotificationHandler()
-    
-    
     var body: some View {
         VStack {
             
@@ -59,8 +56,6 @@ struct LoginView: View {
                     if !viewModel.showAlert {
                         print("Successful sign in.")
                         showSignInView = false
-                        notify.askPermission() // This will only be done once, not every time a user signs in
-                        notify.sendLastReviewNotification(date: Date())
                         
                         if locationService.userLocation == nil{
                             locationService.requestLocationAuthorization()


### PR DESCRIPTION
- Closes #110 
- Changes notification permission timing, so now it's not done after login, it's done every app launch. Please remember that the `askPermission()` function only asks permission if it hasn't been asked before, not every time it's called, meaning that it won't ask permission every time the app is opened.
- Fixes bug where uninstalling and re-installing the app deleted the permission but didn't ask for it again
- Although it doesn't use the same strategy as the location permission (see the comment I made inside the issue), it has the same timing, so both permissions will be asked subsequently 

Lmk if you have any questions or want changes made 