### PR TITLE
[PATCH] Reverts sorting function to previous version

### DIFF
--- a/FoodBookApp/Utils/Utils.swift
+++ b/FoodBookApp/Utils/Utils.swift
@@ -78,17 +78,22 @@ final class Utils {
     }
     
     func highestCategories(spot: Spot) -> [Category] {
-        var sortedCategories = spot.categories
-        let group = DispatchGroup()
-        
-        DispatchQueue.concurrentPerform(iterations: sortedCategories.count) { index in
-            group.enter()
+            var sortedCategories = [Category]()
+            let queue = DispatchQueue(label: "sortingQueue", attributes: .concurrent)
+
+            DispatchQueue.concurrentPerform(iterations: spot.categories.count) { index in
+                let category = spot.categories[index]
+                queue.async(flags: .barrier) {
+                    sortedCategories.append(category)
+                }
+            }
+
+            queue.sync(flags: .barrier) {}
+
             sortedCategories.sort { $0.count > $1.count }
-            group.leave()
+
+            return sortedCategories
         }
-        group.wait()
-        return sortedCategories
-    }
 
     func saveLocalImage(image: UIImage?, imageName: String) {
         let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent(imageName)


### PR DESCRIPTION
- Closes #181 
- Reverts the sorting function to the previous version because the new one causes the app to freeze