### PR TITLE
[PATCH] EC reviews uploaded twice (v2)

### DIFF
--- a/FoodBookApp/UI/Views/Bookmarks/BookmarksView.swift
+++ b/FoodBookApp/UI/Views/Bookmarks/BookmarksView.swift
@@ -27,16 +27,6 @@ struct BookmarksView: View {
                     .foregroundColor(/*@START_MENU_TOKEN@*/.blue/*@END_MENU_TOKEN@*/)
                     .font(.system(size: 100))
                 Text("You have no saved bookmarks.")
-            }.onAppear { // TODO: add this to other view maybe?
-                Task {
-                    do {
-                        if networkService.isOnline {
-                            try await DBManager().uploadReviews()
-                        }
-                    } catch {
-                        print("Error uploading reviews: ", error.localizedDescription)
-                    }
-                }
             }
         }
         else {
@@ -65,16 +55,6 @@ struct BookmarksView: View {
                             .fixedSize(horizontal: false, vertical: true)
                             .accentColor(.black)
                         }
-                    }
-                }
-            }.onAppear { // TODO: add this to other view maybe?
-                Task {
-                    do {
-                        if networkService.isOnline {
-                            try await DBManager().uploadReviews()
-                        }
-                    } catch {
-                        print("Error uploading reviews: ", error.localizedDescription)
                     }
                 }
             }

--- a/FoodBookApp/UI/Views/Browse/BrowseView.swift
+++ b/FoodBookApp/UI/Views/Browse/BrowseView.swift
@@ -50,17 +50,6 @@ struct BrowseView: View {
                 
             }
         }
-        .onAppear { // TODO: add this to other view maybe?
-            Task {
-                do {
-                    if networkService.isOnline {
-                        try await DBManager().uploadReviews()
-                    }
-                } catch {
-                    print("Error uploading reviews: ", error.localizedDescription)
-                }
-            }
-        }
         .padding(8)
     }
     

--- a/FoodBookApp/UI/Views/Content/ContentView.swift
+++ b/FoodBookApp/UI/Views/Content/ContentView.swift
@@ -40,7 +40,7 @@ struct ContentView: View {
     @State private var lastAlertTime: Date? = nil
 
     @ObservedObject var networkService = NetworkService.shared
-    
+    @ObservedObject var dbManager = DBManager.shared
     
     var body: some View {
         NavigationStack {
@@ -79,6 +79,26 @@ struct ContentView: View {
             }
             .onAppear {
                 self.inputHistory = model.loadInputHistory()
+                Task {
+                    if networkService.isOnline && !dbManager.uploading {
+                        do {
+                            try await DBManager.shared.uploadReviews()
+                        } catch {
+                            print("Error uploading reviews: ", error.localizedDescription)
+                        }
+                    }
+                }
+            }
+            .onChange(of: networkService.isOnline) {
+                Task {
+                    if networkService.isOnline && !dbManager.uploading {
+                        do {
+                            try await DBManager.shared.uploadReviews() 
+                        } catch {
+                            print("Error uploading reviews: ", error.localizedDescription)
+                        }
+                    }
+                }
             }
             .navigationTitle(selectedTab.formattedTitle)
             .navigationBarTitleDisplayMode(.inline)

--- a/FoodBookApp/UI/Views/ForYou/ForYouView.swift
+++ b/FoodBookApp/UI/Views/ForYou/ForYouView.swift
@@ -56,16 +56,6 @@ struct ForYouView: View {
                     ProgressView()
                 }
             }
-        }.onAppear { // TODO: add this to other view maybe?
-            Task {
-                do {
-                    if networkService.isOnline {
-                        try await DBManager().uploadReviews()
-                    }
-                } catch {
-                    print("Error uploading reviews: ", error.localizedDescription)
-                }
-            }
         }
         .padding(8)
         


### PR DESCRIPTION
- Closes #185 
- I found what was causing the issue and it was because it wasn't using a singleton, so I fixed that 
   <img alt="drake and lil yachty computer" height="150" src="https://media.tenor.com/jRhv4G-uAjIAAAAM/231.gif">
- Changes where  `uploadReviews()` is called, now it's not on the Browse, ForYou and Bookmarks views, it's on the ContentView file, which avoids the repetition of code. It also adds an onChange modifier so the user doesn't have to manually change views to upload the reviews
- For some reason, this change also makes the reviews be uploaded in every (or at least almost every) view if connection is recovered, which is good!! This basically means that wherever the user is, if they have connection, the reviews will be uploaded. I'm guessing it's because I'm using an onChange and the views are on top of each other (?)