### PR TITLE
[FIX] M.O. (most) ForEach loops are now indexed

### DIFF
--- a/FoodBookApp/UI/Components/HCategoryList.swift
+++ b/FoodBookApp/UI/Components/HCategoryList.swift
@@ -14,8 +14,8 @@ struct HCategoryList: View {
     var body: some View {
         ScrollView(.horizontal) {
             HStack {
-                ForEach(categories, id: \.self){
-                    cat in
+                ForEach(categories.indices, id: \.self){ index in
+                    let cat = categories[index]
                     Text(cat.name.capitalized)
                         .padding(8)
                         .background(color.opacity(0.2))
@@ -30,10 +30,10 @@ struct HCategoryList: View {
 }
 
 
-#Preview {
-    HCategoryList(
-        categories: [ Category(name: "sandwich", count: 1),  Category(name: "healthy", count: 1),  Category(name: "organic", count: 1),  Category(name: "fast", count: 2),  Category(name: "burger", count: 2),  Category(name: "low-fat", count: 1),  Category(name: "fries", count: 1)]
-,
-        color: Color.gray
-    )
-}
+//#Preview {
+//    HCategoryList(
+//        categories: [ Category(name: "sandwich", count: 1),  Category(name: "healthy", count: 1),  Category(name: "organic", count: 1),  Category(name: "fast", count: 2),  Category(name: "burger", count: 2),  Category(name: "low-fat", count: 1),  Category(name: "fries", count: 1)]
+//,
+//        color: Color.gray
+//    )
+//}

--- a/FoodBookApp/UI/Components/ReviewCard.swift
+++ b/FoodBookApp/UI/Components/ReviewCard.swift
@@ -78,7 +78,8 @@ struct ReviewCard: View {
                 // Categories
                 ScrollView(.horizontal) {
                     HStack {
-                        ForEach(review.selectedCategories, id: \.self) { tag in
+                        ForEach(review.selectedCategories.indices, id: \.self) { index in
+                            let tag = review.selectedCategories[index]
                             Text(tag.capitalized)
                                 .font(.system(size: 14))
                                 .bold()

--- a/FoodBookApp/UI/Views/Bookmarks/BookmarksView.swift
+++ b/FoodBookApp/UI/Views/Bookmarks/BookmarksView.swift
@@ -40,7 +40,8 @@ struct BookmarksView: View {
                         .multilineTextAlignment(.center)
                         .safeAreaPadding()
                 } else {
-                    ForEach(model.spots, id: \.self) {spot in
+                    ForEach(model.spots.indices, id: \.self) {index in
+                        let spot = model.spots[index]
                         NavigationLink(destination: SpotDetailView(spotId: spot.id ?? "")){
                             SpotCard(
                                 id: spot.id ?? "",

--- a/FoodBookApp/UI/Views/Browse/BrowseView.swift
+++ b/FoodBookApp/UI/Views/Browse/BrowseView.swift
@@ -54,7 +54,8 @@ struct BrowseView: View {
                             .multilineTextAlignment(.center)
                             .safeAreaPadding()
                     } else {
-                        ForEach(searchResults, id: \.self) { spot in
+                        ForEach(searchResults.indices, id: \.self) { index in
+                            let spot = searchResults[index]
                             NavigationLink(destination: SpotDetailView(spotId: spot.id ?? "")){
                                 SpotCard(
                                     id: spot.id ?? "",

--- a/FoodBookApp/UI/Views/BugReport/BugReportView.swift
+++ b/FoodBookApp/UI/Views/BugReport/BugReportView.swift
@@ -24,6 +24,9 @@ struct BugReportView: View {
     @State private var activeAlert: ActiveAlert? = nil
     @State private var draftMode = false
     
+    @State private var bugTypeList = ["Unexpected Behavior", "Crash", "Other"];
+    @State private var severityLevelList = ["Major", "Minor"];
+    
     var body: some View {
         VStack {
             if !networkService.isOnline {
@@ -47,13 +50,15 @@ struct BugReportView: View {
                 }
                 Section(header: Text("Bug Type and Severity")) {
                     Picker("Bug Type", selection: $bugType) {
-                        ForEach(["Unexpected Behavior", "Crash", "Other"], id: \.self) {
-                            Text($0)
+                        ForEach(bugTypeList.indices, id: \.self) { index in
+                            let bugTypeElement = bugTypeList[index];
+                            Text(bugTypeElement);
                         }
                     }
                     Picker("Severity Level", selection: $severityLevel) {
-                        ForEach(["Minor", "Major"], id: \.self) {
-                            Text($0)
+                        ForEach(severityLevelList.indices, id: \.self) { index in
+                            let severityLevelElement = severityLevelList[index];
+                            Text(severityLevelElement)
                         }
                     }
                 }

--- a/FoodBookApp/UI/Views/CreateReview/CreateReview1View.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview1View.swift
@@ -151,7 +151,8 @@ struct CreateReview1View: View {
                     ScrollView() {
                         VStack(alignment: .leading, spacing: 0) {
                             LazyVGrid(columns: [GridItem(.adaptive(minimum: 100))], alignment: .leading) {
-                                ForEach(searchResults, id: \.self) { cat in
+                                ForEach(searchResults.indices, id: \.self) { index in
+                                    let cat = searchResults[index]
                                     Button(action: {
                                         if selectedCats.contains(cat) {
                                             selectedCats.removeAll { $0 == cat }

--- a/FoodBookApp/UI/Views/CreateReview/CreateReview2View.swift
+++ b/FoodBookApp/UI/Views/CreateReview/CreateReview2View.swift
@@ -37,6 +37,8 @@ struct CreateReview2View: View {
     let notify = NotificationHandler()
     @State private var model = CreateReview2ViewModel()
     
+    @State private var doneTapped = false;
+    
     let customGray = Color(red: 242/255, green: 242/255, blue: 242/255)
     let customGray2 = Color(red: 242/255, green: 242/255, blue: 247/255)
     
@@ -115,6 +117,7 @@ struct CreateReview2View: View {
                                 showFillStarsAlert.toggle()
                             }
                             else {
+                                doneTapped = true;
                                 let reviewDate = Date()
                                 let lowercasedCategories = categories.map { $0.lowercased() }
                                 let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -144,7 +147,7 @@ struct CreateReview2View: View {
                         }, label: {
                             Text("Done")
                                 .frame(maxWidth: .infinity)
-                        })
+                        }).disabled(doneTapped)
                     }
                 
                 // Photo
@@ -330,6 +333,6 @@ struct CreateReview2View: View {
     }
 }
 
-#Preview {
-    CreateReview2View(categories: ["Homemade", "Colombian"], spotId: "ms1hTTxzVkiJElZiYHAT", draftMode: false, shouldCount: .constant(false), imageChange: .constant(false), selectedImage: .constant(nil), cleanliness: .constant(0), waitingTime: .constant(0), foodQuality: .constant(0), service: .constant(0), title: .constant(""), content: .constant(""), isNewReviewSheetPresented: .constant(true))
-}
+//#Preview {
+//    CreateReview2View(categories: ["Homemade", "Colombian"], spotId: "ms1hTTxzVkiJElZiYHAT", draftMode: false, shouldCount: .constant(false), imageChange: .constant(false), selectedImage: .constant(nil), cleanliness: .constant(0), waitingTime: .constant(0), foodQuality: .constant(0), service: .constant(0), title: .constant(""), content: .constant(""), isNewReviewSheetPresented: .constant(true))
+//}

--- a/FoodBookApp/UI/Views/ForYou/ForYouView.swift
+++ b/FoodBookApp/UI/Views/ForYou/ForYouView.swift
@@ -51,7 +51,8 @@ struct ForYouView: View {
                         .multilineTextAlignment(.center)
                         .safeAreaPadding()
                 } else {
-                    ForEach(self.spots, id: \.self) { spot in
+                    ForEach(self.spots.indices, id: \.self) { index in
+                        let spot = spots[index]
                         NavigationLink(
                             destination: SpotDetailView(spotId: spot.id ?? ""))
                         {

--- a/FoodBookApp/UI/Views/Reviews/ReviewsView.swift
+++ b/FoodBookApp/UI/Views/Reviews/ReviewsView.swift
@@ -45,7 +45,9 @@ struct ReviewsView: View {
                 NavigationStack {
                     ScrollView(.vertical) {
                         VStack {
-                            ForEach(reviews.reversed(), id: \.self) { review in
+                            ForEach(reviews.indices, id: \.self) { index in
+                                let reversedIndex = reviews.count - 1 - index
+                                let review = reviews[reversedIndex]
                                 ReviewCard(review: review, userId: model.username)
                             }.padding(.vertical, 5)
                         }

--- a/FoodBookApp/UI/Views/SpotDetail/SpotDetailView.swift
+++ b/FoodBookApp/UI/Views/SpotDetail/SpotDetailView.swift
@@ -86,7 +86,9 @@ struct SpotDetailView: View {
                             TipView(scrollTip, arrowEdge: .leading)
                             ScrollView(.horizontal) {
                                 HStack {
-                                    ForEach(Utils.shared.highestCategories(spot: model.spot), id: \.self) { cat in
+                                    let highestCategories = Utils.shared.highestCategories(spot: model.spot)
+                                    ForEach(highestCategories.indices, id: \.self) { index in
+                                        let cat = highestCategories[index]
                                         Text("\(cat.name.capitalized) (\(cat.count))")
                                             .font(.system(size: 14))
                                             .bold()

--- a/FoodBookApp/UI/Views/UserReviews/UserReviewsView.swift
+++ b/FoodBookApp/UI/Views/UserReviews/UserReviewsView.swift
@@ -47,7 +47,8 @@ struct UserReviewsView: View {
                         }
                         ScrollView(.vertical) {
                             VStack {
-                                ForEach(model.userReviews, id: \.self) { review in
+                                ForEach(model.userReviews.indices, id: \.self) { index in
+                                    let review = model.userReviews[index]
                                     ReviewCard(review: review, userId: username)
                                 }
                                 .padding(.vertical, 5)


### PR DESCRIPTION
- Closes #203 
- Changes all ForEach loops that looped over an array to indexed loops. 

Bonus:
- Adds disabling logic for 'Done' button in CreateReview2View

Lmk if you have any questions or want changes made 

The scenario involved creating a review and then checking its upload in the Reviews view. Notice the slight decrease in time spent for each thread that took # seconds (ignore ms, the difference is irrelevant).

**Before M.O.**

<img width="800" alt="before mico opt" src="https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/495d6581-a085-45c4-a52d-25a165d3ddd6">


**After M.O.**

<img width="800" alt="after micro opt" src="https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/69609680/cc0a64e0-f900-45e1-b585-cc1c33a97a1f">

