### PR TITLE
[FIX] Review fetching with TaskGroups

### DIFF
--- a/FoodBookApp/ServiceAdapter/Firebase/SpotSAFirebase.swift
+++ b/FoodBookApp/ServiceAdapter/Firebase/SpotSAFirebase.swift
@@ -22,11 +22,6 @@ class SpotSAFirebase: SpotSA {
         let spot = try snapshot.data(as: SpotDTO.self)
         var reviews = [Review]()
         
-        //        for reviewRef in spot.reviewData.userReviews {
-        //            let review = try await self.getReview(ref: reviewRef)
-        //            reviews.append(review)
-        //        }
-        
         // Use a task group to fetch reviews concurrently
         try await withThrowingTaskGroup(of: Review.self) { group in
             for reviewRef in spot.reviewData.userReviews {

--- a/FoodBookApp/ServiceAdapter/Firebase/SpotSAFirebase.swift
+++ b/FoodBookApp/ServiceAdapter/Firebase/SpotSAFirebase.swift
@@ -37,8 +37,6 @@ class SpotSAFirebase: SpotSA {
         }
         
         print("FIREBASE: Completed spot fetch \(documentId)")
-        
-        print("FIREBASE: Completed spot fetch \(documentId)")
         return Spot(categories: spot.categories, location: spot.location, name: spot.name, price: spot.price, waitTime: spot.waitTime, reviewData: ReviewData(stats: spot.reviewData.stats, userReviews: reviews), imageLinks: spot.imageLinks)
     }
     


### PR DESCRIPTION
* Fixes #205 


Changes the logic of fetching in reviews for a spot. Instead of being serial, this is done using `TaskGroups` where each `Task` has the responsibility of fetching a review given it's snapshot. From a user's perspective this significantly reduced the loading time in Spots with more reviews.

**Changes made**
1. **Refactored Query Execution:**
   - **Before MO:** 
     ```swift
     for reviewRef in spot.reviewData.userReviews {
            let review = try await self.getReview(ref: reviewRef)
            reviews.append(review)
        }
     ```
   - **After MO:** 
     ```swift
     // Use a task group to fetch reviews concurrently
        try await withThrowingTaskGroup(of: Review.self) { group in
            for reviewRef in spot.reviewData.userReviews {
                group.addTask {
                    return try await self.getReview(ref: reviewRef)
                }
            }
            
            // Collect all reviews
            for try await review in group {
                reviews.append(review)
            }
        }
     ```


## Profiling

Take a look at the changes in the stack weight (ms) before and after the optimization. The scenario was run on an iPhone 11. 

**BEFORE**
![Screenshot 2024-05-25 at 8 12 09 PM](https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/61592394/aa259dfd-cc42-440f-984b-ee39ec6f5c55)

**AFTER**

![Screenshot 2024-05-25 at 8 02 16 PM](https://github.com/ISIS3510-202410-Team23/SwiftApp/assets/61592394/15af41bd-fa2d-4538-a8aa-24cda2361bf6)

